### PR TITLE
Fix mkInputs to not use nixpkgs in flake.nix

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -28,7 +28,7 @@
           _module.args = {
             systemType = "wsl";
             desktop = false;
-            inherit trusted baze;
+            inherit system trusted baze;
           };
         }
       ]
@@ -64,7 +64,7 @@
           networking.hostName = name;
           _module.args = {
             systemType = "bare";
-            inherit desktop trusted baze;
+            inherit system desktop trusted baze;
           };
         }
       ]

--- a/home.nix
+++ b/home.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  system,
   systemType,
   baze,
   trusted ? false,


### PR DESCRIPTION
Pass `system` parameter to `home.nix` to resolve an undefined variable error when accessing `baze.packages`.

The initial issue reported was about `mkInputs` not using `nixpkgs`. However, the root cause was found to be `system` not being passed as a parameter to the `home.nix` module, leading to an undefined variable error when attempting to access `baze.packages.${system}.default`. This PR adds `system` to the module parameters and ensures it's passed from `build.nix`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bab5f41-d79d-4de8-a21e-9876252f1804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bab5f41-d79d-4de8-a21e-9876252f1804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

